### PR TITLE
use tmpfs + ppc64 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
+# syntax=docker/dockerfile:1.3
+
 ARG BASE
 
 FROM ${BASE}
 
-CMD cp -a /var/cache/binpkgs /tmp/binpkg \
+CMD --mount=type=tmpfs,target=/var/tmp/portage \
+ cp -a /var/cache/binpkgs /tmp/binpkg \
  && FEATURES=test emerge -1vB ${PKG} \
  && emerge -1vk ${PKG} \
  && { [[ -z ${POST_PKGS} ]] || emerge -1vt --keep-going=y --jobs ${POST_PKGS}; } \

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.3
+
 ARG BASE
 
 FROM ${BASE}
@@ -10,6 +12,7 @@ ARG CFLAGS
 
 COPY package.accept_keywords /etc/portage
 COPY package.use /etc/portage/package.use/local
-RUN printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\n' "${CFLAGS}" "${CFLAGS}" >> /etc/portage/make.conf \
+RUN --mount=type=tmpfs,target=/var/tmp/portage \
+ printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\n' "${CFLAGS}" "${CFLAGS}" >> /etc/portage/make.conf \
  && { [[ -z ${DEPS} ]] || emerge -1vt --jobs ${DEPS}; } \
  && cat /etc/portage/make.conf

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -10,7 +10,7 @@ RUN wget --progress=dot:mega -O - https://github.com/gentoo-mirror/gentoo/archiv
 ARG DEPS
 ARG CFLAGS
 
-COPY package.accept_keywords /etc/portage
+COPY package.accept_keywords /etc/portage/package.accept_keywords/mgorny-binpkg-docker
 COPY package.use /etc/portage/package.use/local
 RUN --mount=type=tmpfs,target=/var/tmp/portage \
  printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\n' "${CFLAGS}" "${CFLAGS}" >> /etc/portage/make.conf \

--- a/build.bash
+++ b/build.bash
@@ -215,6 +215,9 @@ export_vars() {
 	if [[ -v ${host_varname} ]]; then
 		export DOCKER_HOST=${!host_varname}
 	fi
+
+	export DOCKER_BUILDKIT=1
+	export BUILDKIT_PROGRESS=plain
 }
 
 do_prune() {

--- a/build.bash
+++ b/build.bash
@@ -186,6 +186,7 @@ export_vars() {
 		arm64)
 			;;
 		ppc64le)
+			stage=gentoo/stage3:ppc64le-openrc
 			cflags='-mcpu=power8 -mtune=power8 -O2 -pipe'
 			;;
 		x86)


### PR DESCRIPTION
use new buildkit features and dockerfile syntax line
keep old output format
seems it was pulling outdated stage3 from dockerhub, one from july 2021, which has pre-eapi8 portage.

on some new stages `/etc/package.accept_keywords` is an empty dir, fix copy fail.
^ this need verification on stages where  there's no `/etc/package.accept_keywords` dir. maybe simply omitting last path component of file target name will make it work on both.

marking as draft.
will post build times soon.